### PR TITLE
Add auto greeting every 30s

### DIFF
--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "scale:load"
+  ]
+}

--- a/data/minecraft/tags/functions/tick.json
+++ b/data/minecraft/tags/functions/tick.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "scale:tick"
+  ]
+}

--- a/data/scale/function/load.mcfunction
+++ b/data/scale/function/load.mcfunction
@@ -1,0 +1,2 @@
+scoreboard objectives add scale.timer dummy
+scoreboard players set #timer scale.timer 0

--- a/data/scale/function/tick.mcfunction
+++ b/data/scale/function/tick.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players add #timer scale.timer 1
+execute if score #timer scale.timer matches 600.. run function scale:bonjour
+execute if score #timer scale.timer matches 600.. run scoreboard players set #timer scale.timer 0


### PR DESCRIPTION
## Summary
- run `scale:tick` every game tick and `scale:load` on load
- add timer scoreboard and tick logic
- greet players every 30 seconds

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859d55edca0832b988a3d55cf0db321