### PR TITLE
Add mob size toggle

### DIFF
--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "scale:load"
+  ]
+}

--- a/data/minecraft/tags/functions/tick.json
+++ b/data/minecraft/tags/functions/tick.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "scale:tick"
+  ]
+}

--- a/data/scale/function/interval.mcfunction
+++ b/data/scale/function/interval.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players set #timer scale.timer 0
+scoreboard players add #state scale.state 1
+execute if score #state scale.state matches 2.. run scoreboard players set #state scale.state 0
+function scale:bonjour

--- a/data/scale/function/load.mcfunction
+++ b/data/scale/function/load.mcfunction
@@ -1,0 +1,4 @@
+scoreboard objectives add scale.timer dummy
+scoreboard objectives add scale.state dummy
+scoreboard players set #timer scale.timer 0
+scoreboard players set #state scale.state 0

--- a/data/scale/function/tick.mcfunction
+++ b/data/scale/function/tick.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players add #timer scale.timer 1
+execute if score #timer scale.timer matches 600.. run function scale:interval
+execute as @e[type=!player] if score #state scale.state matches 0 run attribute @s minecraft:scale base set 4
+execute as @e[type=!player] if score #state scale.state matches 1 run attribute @s minecraft:scale base set 1


### PR DESCRIPTION
## Summary
- add a `scale.state` scoreboard and setup in `load.mcfunction`
- create `interval.mcfunction` to toggle mob size and send the message
- update `tick.mcfunction` to call `interval` and apply scale based on state

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859d55edca0832b988a3d55cf0db321